### PR TITLE
Add deletedAt column to Tournament entity

### DIFF
--- a/src/tournament/entities/tournament.entity.ts
+++ b/src/tournament/entities/tournament.entity.ts
@@ -1,6 +1,6 @@
 import { Player } from 'src/players/entities/player.entity';
 import { Result } from 'src/results/entities/result.entity';
-import { Column, Entity, JoinTable, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinTable, OneToMany, PrimaryGeneratedColumn, DeleteDateColumn } from 'typeorm';
 
 @Entity('tournaments')
 export class Tournament {
@@ -16,4 +16,7 @@ export class Tournament {
   @OneToMany(() => Result, (result) => result.tournament)
   @JoinTable()
   players: Player[];
+
+  @DeleteDateColumn()
+  deletedAt?: Date;
 }


### PR DESCRIPTION
This PR introduces a new `deletedAt` column to the Tournament entity. This column is managed by TypeORM's @DeleteDateColumn decorator, which automatically sets the column's value to the current date when the entity is soft deleted.

This change allows us to keep track of when a Tournament entity was soft deleted, which can be useful for auditing purposes and can help us implement features like undo delete in the future.