### PR TITLE
Allow creating tournaments with an empty player list

### DIFF
--- a/src/tournament/entities/tournament.entity.ts
+++ b/src/tournament/entities/tournament.entity.ts
@@ -15,7 +15,7 @@ export class Tournament {
 
   @OneToMany(() => Result, (result) => result.tournament)
   @JoinTable()
-  players: Player[];
+  players?: Player[];
 
   @DeleteDateColumn()
   deletedAt?: Date;


### PR DESCRIPTION
This PR allows creating tournaments without initial players. The players property in the Tournament entity has been changed to players?: Player[] to permit empty lists. This aligns with the requirement to allow tournament creation without players and enables adding participants later through a dedicated endpoint.