### PR TITLE
Allow creating tournaments with an empty player list in DTO

### DIFF
--- a/src/tournament/dtos/create-tournament.dto.ts
+++ b/src/tournament/dtos/create-tournament.dto.ts
@@ -25,8 +25,7 @@ export class CreateTournamentDto {
   })
   description: string;
 
-  @ArrayNotEmpty({ message: 'La lista de jugadores no puede estar vacía' })
   @ValidateNested({ each: true })
   @Type(() => CreatePlayerDto)
-  players: CreatePlayerDto[];
+  players?: CreatePlayerDto[];
 }


### PR DESCRIPTION
This PR allows creating tournaments without initial players in the CreateTournamentDto. The players property has been changed to players?: CreatePlayerDto[] to permit empty lists. This aligns with the requirement to allow tournament creation without players and enables adding participants later through a dedicated endpoint.

- Change `players` property to `players?: CreatePlayerDto[]` in `CreateTournamentDto`.